### PR TITLE
Add voting flow handling and UI

### DIFF
--- a/src/app/player/game-shell.component.ts
+++ b/src/app/player/game-shell.component.ts
@@ -30,7 +30,7 @@ import { DebateComponent } from './ui/debate.component';
           <player-lobby *ngSwitchCase="'LOBBY'" [vm]="vm"></player-lobby>
           <player-role-assignment *ngSwitchCase="'ROLE_ASSIGNMENT'" [vm]="vm"></player-role-assignment>
           <player-answer *ngSwitchCase="'ANSWER'" [vm]="vm"></player-answer>
-          <player-vote *ngSwitchCase="'VOTE'"></player-vote>
+          <player-vote *ngSwitchCase="'VOTE'" [vm]="vm"></player-vote>
           <player-results *ngSwitchCase="'RESULTS'"></player-results>
           <player-debate *ngSwitchCase="'DEBATE'" [vm]="vm"></player-debate>
           <player-lobby *ngSwitchDefault [vm]="vm"></player-lobby>

--- a/src/app/player/models.ts
+++ b/src/app/player/models.ts
@@ -71,4 +71,5 @@ export interface PlayerViewModel {
   connectionState: ConnectionState;
   currentQuestion: PlayerQuestion | null;
   isImpostor: boolean | null;
+  voteOptions?: VoteOption[];
 }

--- a/src/app/player/player-api.service.ts
+++ b/src/app/player/player-api.service.ts
@@ -34,11 +34,11 @@ export class PlayerApiService {
     });
   }
 
-  vote(roomCode: string, playerId: string, voteFor: string): Observable<unknown> {
-    return this.http.post(`${this.baseUrl}/player/vote`, {
+  vote(roomCode: string, playerId: string, votedPlayerId: string): Observable<unknown> {
+    return this.http.post(`${this.baseUrl}/game/${roomCode}/send-votes`, {
       roomCode,
       playerId,
-      voteFor,
+      votedPlayerId,
     });
   }
 }

--- a/src/app/player/player-client.service.ts
+++ b/src/app/player/player-client.service.ts
@@ -61,6 +61,7 @@ export class PlayerClientService {
       this.eventSource.addEventListener('ROLES_ASIGNADOS', handleEvent);
       this.eventSource.addEventListener('PREGUNTA_ASIGNADA', handleEvent);
       this.eventSource.addEventListener('DEBATE_INICIADO', handleEvent);
+      this.eventSource.addEventListener('VOTACION_INICIADA', handleEvent);
       this.eventSource.onerror = () => {
         this.zone.run(() => {
           // eslint-disable-next-line no-console

--- a/src/app/player/player-store.service.ts
+++ b/src/app/player/player-store.service.ts
@@ -20,6 +20,7 @@ const initialViewModel: PlayerViewModel = {
   connectionState: 'DISCONNECTED',
   currentQuestion: null,
   isImpostor: null,
+  voteOptions: [],
 };
 
 @Injectable({ providedIn: 'root' })
@@ -42,6 +43,7 @@ export class PlayerStoreService {
       connectionState: payload.connectionState ?? 'CONNECTED',
       currentQuestion: payload.currentQuestion,
       isImpostor: payload.isImpostor ?? null,
+      voteOptions: payload.voteOptions ?? this.snapshot.voteOptions ?? [],
     };
     this.subject.next(nextState);
   }
@@ -114,6 +116,20 @@ export class PlayerStoreService {
       };
       this.subject.next(nextState);
       return;
+    }
+
+    if (event.type === 'VOTACION_INICIADA') {
+      const payload = (event as { payload?: PlayerSnapshotPayload['voteOptions'] }).payload;
+      if (payload) {
+        const nextState: PlayerViewModel = {
+          ...this.snapshot,
+          phase: 'VOTE',
+          state: 'VOTANDO',
+          voteOptions: payload,
+        };
+        this.subject.next(nextState);
+        return;
+      }
     }
 
     this.subject.next({ ...this.snapshot });

--- a/src/app/player/ui/vote.component.ts
+++ b/src/app/player/ui/vote.component.ts
@@ -1,14 +1,165 @@
-import { Component } from '@angular/core';
+import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { finalize } from 'rxjs';
+import { PlayerApiService } from '../player-api.service';
+import { PlayerClientService } from '../player-client.service';
+import { PlayerViewModel, VoteOption } from '../models';
 
 @Component({
   selector: 'player-vote',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, FormsModule],
   template: `
-    <div class="flex flex-col items-center justify-center h-full">
-      <p class="text-2xl">Hora de votar.</p>
-    </div>
+    <ng-container *ngIf="vm as viewModel">
+      <div class="h-full w-full overflow-hidden flex flex-col">
+        <header class="top-0 w-full bg-white z-50">
+          <h1 class="text-5xl font-bold uppercase tracking-widest text-center py-6">Game Name</h1>
+        </header>
+
+        <main class="flex-1 flex flex-col items-center justify-center">
+          <ng-container *ngIf="!isWaiting(viewModel); else waitingScreen">
+            <div class="justify-center items-center p-8 shadow-sm h-full w-1/2">
+              <p class="text-2xl text-center mb-5">Vota por quien es el traidor</p>
+              <form class="flex flex-col items-center gap-6" (ngSubmit)="onSubmit(viewModel)">
+                <div class="flex flex-col gap-2">
+                  <label class="font-bold">¿Quién es el traidor?</label>
+
+                  <label
+                    class="flex items-center gap-2"
+                    *ngFor="let option of availableOptions"
+                  >
+                    <input
+                      type="radio"
+                      name="voto"
+                      [value]="option.playerId"
+                      [(ngModel)]="selectedVote"
+                      [disabled]="submitting"
+                    />
+                    {{ option.playerName }}
+                  </label>
+
+                  <label class="flex items-center gap-2">
+                    <input
+                      type="radio"
+                      name="voto"
+                      [value]="skipValue"
+                      [(ngModel)]="selectedVote"
+                      [disabled]="submitting"
+                    />
+                    Saltar votación
+                  </label>
+                </div>
+                <button
+                  class="text-4xl font-bold underline hover:text-gray-700 disabled:text-gray-400"
+                  type="submit"
+                  [disabled]="submitting || !selectedVote"
+                >
+                  Votar
+                </button>
+                <p *ngIf="submitError" class="text-red-600 text-base text-center">
+                  {{ submitError }}
+                </p>
+              </form>
+            </div>
+          </ng-container>
+
+          <ng-template #waitingScreen>
+            <div class="flex flex-col items-center justify-center h-full gap-8">
+              <div>
+                <div class="flex flex-col items-center gap-4">
+                  <div
+                    class="w-48 h-48 rounded-full border-2 border-gray-300 bg-gray-100 flex items-center justify-center"
+                    aria-label="Avatar del jugador"
+                  >
+                    <span class="text-6xl font-bold text-gray-400">
+                      {{ (viewModel.name || 'J')[0] }}
+                    </span>
+                  </div>
+                  <p class="text-4xl text-center">{{ viewModel.name || 'Jugador' }}</p>
+                </div>
+                <div class="m-5">
+                  <p class="text-2xl text-center">Esperando a que todos contesten...</p>
+                </div>
+              </div>
+            </div>
+          </ng-template>
+        </main>
+      </div>
+    </ng-container>
   `,
 })
-export class VoteComponent {}
+export class VoteComponent implements OnChanges {
+  @Input() vm: PlayerViewModel | null = null;
+
+  availableOptions: VoteOption[] = [];
+  selectedVote = '';
+  submitting = false;
+  submitError = '';
+  private submitted = false;
+  private lastOptionsKey = '';
+  private lastState: PlayerViewModel['state'] | null = null;
+  readonly skipValue = '__SKIP_VOTE__';
+
+  constructor(
+    private readonly api: PlayerApiService,
+    private readonly client: PlayerClientService,
+  ) {}
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['vm']) {
+      const viewModel = this.vm;
+      const options = viewModel?.voteOptions ?? [];
+      const filteredOptions = options.filter((option) => option.playerId !== viewModel?.playerId);
+      const optionsKey = filteredOptions
+        .map((option) => `${option.playerId}:${option.playerName}`)
+        .join('|');
+      if (optionsKey !== this.lastOptionsKey) {
+        this.availableOptions = filteredOptions;
+        this.selectedVote = '';
+        this.submitted = false;
+        this.submitError = '';
+        this.lastOptionsKey = optionsKey;
+      }
+      if (viewModel?.state === 'VOTANDO' && this.lastState === 'VOTO_ENVIADO') {
+        this.submitted = false;
+        this.submitError = '';
+      }
+      this.lastState = viewModel?.state ?? null;
+    }
+  }
+
+  isWaiting(viewModel: PlayerViewModel): boolean {
+    return this.submitted || viewModel.state === 'VOTO_ENVIADO';
+  }
+
+  onSubmit(viewModel: PlayerViewModel): void {
+    if (this.submitting || !this.selectedVote) {
+      return;
+    }
+    const roomCode = viewModel.roomCode;
+    const playerId = viewModel.playerId;
+    if (!roomCode || !playerId) {
+      return;
+    }
+    const votedPlayerId = this.selectedVote === this.skipValue ? '' : this.selectedVote;
+    this.submitting = true;
+    this.submitError = '';
+    this.api
+      .vote(roomCode, playerId, votedPlayerId)
+      .pipe(
+        finalize(() => {
+          this.submitting = false;
+        }),
+      )
+      .subscribe({
+        next: () => {
+          this.submitted = true;
+        },
+        error: (error: { error?: { message?: string } }) => {
+          this.submitError = error?.error?.message ?? 'No se pudo enviar el voto.';
+          this.client.connect(roomCode, playerId);
+        },
+      });
+  }
+}


### PR DESCRIPTION
### Motivation
- Introduce the in-game voting screen and wire server events so the client shows the voting page when a `VOTACION_INICIADA` event arrives or when a snapshot has the player state `VOTANDO`.

### Description
- Implement a full `player-vote` UI component with radio options derived from `voteOptions`, filter out the current player so self-voting is not possible, and add a "Saltar votación" option that submits an empty `votedPlayerId` string.
- Persist `voteOptions` in the view model by extending `PlayerViewModel.voteOptions` and populate them from snapshots and from a `VOTACION_INICIADA` SSE event handler in `PlayerStoreService`.
- Register an SSE listener for `VOTACION_INICIADA` in `PlayerClientService` and route the app to the `VOTE` phase when the event or snapshot indicates voting.
- Update the API call to submit votes to the required endpoint `POST http://localhost:8080/game/{roomCode}/send-votes` with the body containing `roomCode`, `playerId`, and `votedPlayerId`, and reconnect the SSE client on vote submission error.

### Testing
- Ran `npm run start` (Angular dev server) and the build completed and the dev server reported successful startup; this succeeded.
- Executed a Playwright script that opened the app, injected a snapshot with `state: 'VOTANDO'` and `voteOptions`, and captured `artifacts/vote-screen.png`; the script completed and produced the screenshot successfully.
- No unit/integration test suite was executed (`npm test` not run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e5ca1ba70832db806a41810aecf6f)