### PR TITLE
Add GitHub Actions workflow to tag build artifacts and deploy to GitHub Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,73 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build -- --configuration production --base-href "/${{ github.event.repository.name }}/"
+
+      - name: Create deploy tag
+        env:
+          TAG_NAME: deploy-${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          BUILD_DIR="dist/player"
+          if [ ! -d "$BUILD_DIR" ]; then
+            echo "Build output not found at $BUILD_DIR"
+            exit 1
+          fi
+          DEPLOY_DIR="$(mktemp -d)"
+          cp -R "$BUILD_DIR"/. "$DEPLOY_DIR"/
+          pushd "$DEPLOY_DIR" >/dev/null
+          git init
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git commit -m "Deploy $TAG_NAME"
+          git tag "$TAG_NAME"
+          git remote add origin "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git"
+          git push origin "$TAG_NAME"
+          popd >/dev/null
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist/player
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
### Motivation
- Provide an automated workflow that builds the Angular app, creates a tag containing the deploy-ready files, and publishes the site to GitHub Pages whenever `main` is updated.

### Description
- Added `./github/workflows/deploy.yml` which triggers on `push` to `main` and runs on `ubuntu-latest`.
- The workflow sets up Node.js 20, runs `npm ci` and `npm run build -- --configuration production --base-href "/${{ github.event.repository.name }}/"`, and expects the static output at `dist/player`.
- It copies the build output into a temporary repo, creates a tag named `deploy-${{ github.run_id }}` and pushes that tag back to the repository using the `GITHUB_TOKEN` before uploading the pages artifact and deploying with `actions/deploy-pages@v4`.
- The workflow requests `contents: write`, `pages: write`, and `id-token: write` permissions and uses a concurrency group named `pages`.

### Testing
- No automated tests were executed for this change because it only adds a GitHub Actions workflow and must be validated by running on GitHub Actions after pushing to `main`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e60eb1074832d80235b8997f87113)