### PR TITLE
Style player UI with Trivia Murder Party-inspired theme

### DIFF
--- a/src/app/player/game-shell.component.ts
+++ b/src/app/player/game-shell.component.ts
@@ -23,7 +23,7 @@ import { DebateComponent } from './ui/debate.component';
     DebateComponent,
   ],
   template: `
-    <div class="h-screen w-screen overflow-hidden">
+    <div class="h-screen w-screen overflow-hidden tpm-root">
       <ng-container *ngIf="vm$ | async as vm">
         <ng-container [ngSwitch]="vm.phase">
           <player-join-room *ngSwitchCase="'JOIN'"></player-join-room>

--- a/src/app/player/ui/answer.component.ts
+++ b/src/app/player/ui/answer.component.ts
@@ -12,20 +12,20 @@ import { PlayerViewModel } from '../models';
   template: `
     <ng-container *ngIf="vm as viewModel">
       <div class="h-full w-full overflow-hidden flex flex-col">
-        <header class="top-0 w-full bg-white z-50">
-          <h1 class="text-5xl font-bold uppercase tracking-widest text-center py-6">Game Name</h1>
+        <header class="top-0 w-full tpm-header z-50">
+          <h1 class="text-5xl font-bold uppercase text-center py-6 tpm-title">Game Name</h1>
         </header>
 
         <main class="flex-1 flex flex-col items-center justify-center">
           <ng-container *ngIf="!isWaiting(viewModel); else waitingScreen">
-            <div class="justify-center items-center p-8 shadow-sm h-full w-1/2">
-              <p class="text-2xl text-center mb-5">
+            <div class="justify-center items-center p-8 h-full w-11/12 max-w-2xl tpm-panel">
+              <p class="text-2xl text-center mb-5 tpm-highlight">
                 {{ viewModel.currentQuestion?.pregunta || 'Esperando pregunta...' }}
               </p>
               <form class="flex flex-col items-center gap-6" (ngSubmit)="onSubmit(viewModel)">
                 <div class="w-full">
                   <input
-                    class="text-left border-2 border-gray-300 rounded-lg p-4 w-64 text-xl text-center w-full"
+                    class="tpm-input p-4 text-xl text-center w-full"
                     type="text"
                     name="answerText"
                     placeholder="Responder"
@@ -34,13 +34,13 @@ import { PlayerViewModel } from '../models';
                   />
                 </div>
                 <button
-                  class="text-4xl font-bold underline hover:text-gray-700 disabled:text-gray-400"
+                  class="tpm-button text-3xl font-bold"
                   type="submit"
                   [disabled]="submitting || !answerText.trim()"
                 >
                   Enviar
                 </button>
-                <p *ngIf="submitError" class="text-red-600 text-base text-center">
+                <p *ngIf="submitError" class="text-red-300 text-base text-center">
                   {{ submitError }}
                 </p>
               </form>
@@ -52,16 +52,16 @@ import { PlayerViewModel } from '../models';
               <div>
                 <div class="flex flex-col items-center gap-4">
                   <div
-                    class="w-48 h-48 rounded-full border-2 border-gray-300 bg-gray-100 flex items-center justify-center"
+                    class="w-48 h-48 rounded-full flex items-center justify-center tpm-avatar"
                     aria-label="Avatar del jugador"
                   >
-                    <span class="text-6xl font-bold text-gray-400">
+                    <span class="text-6xl font-bold tpm-avatar-letter">
                       {{ (viewModel.name || 'J')[0] }}
                     </span>
                   </div>
-                  <p class="text-4xl text-center">{{ viewModel.name || 'Jugador' }}</p>
+                  <p class="text-4xl text-center tpm-highlight">{{ viewModel.name || 'Jugador' }}</p>
                 </div>
-                <div class="m-5">
+                <div class="m-5 tpm-panel px-8 py-6">
                   <p class="text-2xl text-center">Esperando a que todos contesten...</p>
                 </div>
               </div>

--- a/src/app/player/ui/debate.component.ts
+++ b/src/app/player/ui/debate.component.ts
@@ -7,23 +7,23 @@ import { PlayerViewModel } from '../models';
   standalone: true,
   imports: [CommonModule],
   template: `
-    <div class="flex flex-col items-center justify-center h-full gap-8">
-      <header class="fixed top-0 w-full bg-white z-50">
-        <h1 class="text-5xl font-bold uppercase tracking-widest text-center py-6">Game Name</h1>
+    <div class="flex flex-col items-center justify-center h-full gap-8 px-6 pt-28">
+      <header class="fixed top-0 w-full tpm-header z-50">
+        <h1 class="text-5xl font-bold uppercase text-center py-6 tpm-title">Game Name</h1>
       </header>
 
       <div class="flex flex-col items-center">
-        <div class="w-48 h-48 rounded-full overflow-hidden shadow-md">
+        <div class="w-48 h-48 rounded-full overflow-hidden tpm-avatar">
           <img
             src="assets/img/avatar.svg"
             alt="Avatar del jugador"
             class="w-full h-full object-cover"
           />
         </div>
-        <p class="text-4xl text-center mt-4">{{ vm?.name || 'nombre player' }}</p>
+        <p class="text-4xl text-center mt-4 tpm-highlight">{{ vm?.name || 'nombre player' }}</p>
       </div>
 
-      <div class="m-5">
+      <div class="m-5 tpm-panel px-8 py-6">
         <p class="text-2xl text-center">Debatan!</p>
       </div>
     </div>

--- a/src/app/player/ui/join-room.component.ts
+++ b/src/app/player/ui/join-room.component.ts
@@ -10,25 +10,25 @@ import { PlayerStoreService } from '../player-store.service';
   standalone: true,
   imports: [CommonModule, FormsModule],
   template: `
-    <div class="flex flex-col items-center justify-center h-full gap-8">
-      <header class="fixed top-0 w-full bg-white z-50">
-        <h1 class="text-5xl font-bold uppercase tracking-widest text-center py-6">Game Name</h1>
+    <div class="flex flex-col items-center justify-center h-full gap-8 px-6 pt-28">
+      <header class="fixed top-0 w-full tpm-header z-50">
+        <h1 class="text-5xl font-bold uppercase text-center py-6 tpm-title">Game Name</h1>
       </header>
 
-      <div class="border-2 border-gray-300 rounded-lg p-8 m-5 shadow-sm bg-white">
+      <div class="tpm-panel p-8 m-5 w-full max-w-md">
         <form
           class="flex flex-col items-center gap-6"
           (ngSubmit)="joinRoom()"
           #joinForm="ngForm"
         >
           <div class="flex flex-col items-start gap-2">
-            <label class="font-bold text-2xl" for="codigo">Código</label>
+            <label class="font-bold text-2xl tpm-accent" for="codigo">Código</label>
             <input
               type="text"
               id="codigo"
               name="codigo"
               placeholder="1234"
-              class="border-2 border-gray-300 rounded-lg p-4 w-64 text-xl text-center"
+              class="tpm-input p-4 w-64 text-xl text-center"
               required
               maxlength="4"
               [(ngModel)]="roomCode"
@@ -36,24 +36,24 @@ import { PlayerStoreService } from '../player-store.service';
           </div>
 
           <div class="flex flex-col items-start gap-2">
-            <label class="font-bold text-2xl" for="nombre">Nombre</label>
+            <label class="font-bold text-2xl tpm-accent" for="nombre">Nombre</label>
             <input
               type="text"
               id="nombre"
               name="nombre"
               placeholder="nombre"
-              class="border-2 border-gray-300 rounded-lg p-4 w-64 text-xl text-center"
+              class="tpm-input p-4 w-64 text-xl text-center"
               required
               [(ngModel)]="playerName"
             />
           </div>
 
-          <p *ngIf="errorMessage" class="text-red-600 text-center text-lg">
+          <p *ngIf="errorMessage" class="text-red-300 text-center text-lg">
             {{ errorMessage }}
           </p>
 
           <button
-            class="font-bold text-4xl underline mt-4 hover:text-gray-700"
+            class="tpm-button text-3xl font-bold mt-4"
             type="submit"
             [disabled]="joinForm.invalid || loading"
           >

--- a/src/app/player/ui/lobby.component.ts
+++ b/src/app/player/ui/lobby.component.ts
@@ -7,24 +7,24 @@ import { PlayerViewModel } from '../models';
   standalone: true,
   imports: [CommonModule],
   template: `
-    <div class="flex flex-col items-center justify-center h-full gap-8">
-      <header class="fixed top-0 w-full bg-white z-50">
-        <h1 class="text-5xl font-bold uppercase tracking-widest text-center py-6">Game Name</h1>
+    <div class="flex flex-col items-center justify-center h-full gap-8 px-6 pt-28">
+      <header class="fixed top-0 w-full tpm-header z-50">
+        <h1 class="text-5xl font-bold uppercase text-center py-6 tpm-title">Game Name</h1>
       </header>
 
       <div>
         <div class="flex flex-col items-center gap-4">
           <div
-            class="w-48 h-48 rounded-full border-2 border-gray-300 bg-gray-100 flex items-center justify-center"
+            class="w-48 h-48 rounded-full flex items-center justify-center tpm-avatar"
             aria-label="Avatar del jugador"
           >
-            <span class="text-6xl font-bold text-gray-400">
+            <span class="text-6xl font-bold tpm-avatar-letter">
               {{ (vm?.name || 'J')[0] }}
             </span>
           </div>
-          <p class="text-4xl text-center">{{ vm?.name || 'Jugador' }}</p>
+          <p class="text-4xl text-center tpm-highlight">{{ vm?.name || 'Jugador' }}</p>
         </div>
-        <div class="m-5">
+        <div class="m-5 tpm-panel px-8 py-6">
           <p class="text-2xl text-center">Esperando a que el host inicie el juego</p>
         </div>
       </div>

--- a/src/app/player/ui/results.component.ts
+++ b/src/app/player/ui/results.component.ts
@@ -6,8 +6,13 @@ import { CommonModule } from '@angular/common';
   standalone: true,
   imports: [CommonModule],
   template: `
-    <div class="flex flex-col items-center justify-center h-full">
-      <p class="text-2xl">Resultados de la ronda.</p>
+    <div class="flex flex-col items-center justify-center h-full gap-8 px-6 pt-28">
+      <header class="fixed top-0 w-full tpm-header z-50">
+        <h1 class="text-5xl font-bold uppercase text-center py-6 tpm-title">Game Name</h1>
+      </header>
+      <div class="tpm-panel px-10 py-8">
+        <p class="text-2xl text-center tpm-highlight">Resultados de la ronda.</p>
+      </div>
     </div>
   `,
 })

--- a/src/app/player/ui/role-assignment.component.ts
+++ b/src/app/player/ui/role-assignment.component.ts
@@ -7,28 +7,28 @@ import { PlayerViewModel } from '../models';
   standalone: true,
   imports: [CommonModule],
   template: `
-    <div class="flex flex-col items-center justify-center h-full gap-8">
-      <header class="fixed top-0 w-full bg-white z-50">
-        <h1 class="text-5xl font-bold uppercase tracking-widest text-center py-6">Game Name</h1>
+    <div class="flex flex-col items-center justify-center h-full gap-8 px-6 pt-28">
+      <header class="fixed top-0 w-full tpm-header z-50">
+        <h1 class="text-5xl font-bold uppercase text-center py-6 tpm-title">Game Name</h1>
       </header>
 
       <div>
         <div class="flex flex-col items-center gap-4">
           <div
-            class="w-48 h-48 rounded-full border-2 border-gray-300 bg-gray-100 flex items-center justify-center overflow-hidden"
+            class="w-48 h-48 rounded-full flex items-center justify-center overflow-hidden tpm-avatar"
             aria-label="Avatar del jugador"
           >
-            <span class="text-6xl font-bold text-gray-400">
+            <span class="text-6xl font-bold tpm-avatar-letter">
               {{ (vm?.name || 'J')[0] }}
             </span>
           </div>
-          <p class="text-4xl text-center">{{ vm?.name || 'Jugador' }}</p>
+          <p class="text-4xl text-center tpm-highlight">{{ vm?.name || 'Jugador' }}</p>
         </div>
-        <div class="text-center text-2xl m-5">
+        <div class="text-center text-2xl m-5 tpm-panel px-8 py-6">
           Tu eres el
           <span
             class="text-2xl font-black uppercase"
-            [ngClass]="vm?.isImpostor ? 'text-red-600' : 'text-blue-600'"
+            [ngClass]="vm?.isImpostor ? 'tpm-danger' : 'tpm-accent'"
           >
             {{ vm?.isImpostor ? 'impostor' : 'ciudadano' }}
           </span>

--- a/src/app/player/ui/vote.component.ts
+++ b/src/app/player/ui/vote.component.ts
@@ -13,20 +13,20 @@ import { PlayerViewModel, VoteOption } from '../models';
   template: `
     <ng-container *ngIf="vm as viewModel">
       <div class="h-full w-full overflow-hidden flex flex-col">
-        <header class="top-0 w-full bg-white z-50">
-          <h1 class="text-5xl font-bold uppercase tracking-widest text-center py-6">Game Name</h1>
+        <header class="top-0 w-full tpm-header z-50">
+          <h1 class="text-5xl font-bold uppercase text-center py-6 tpm-title">Game Name</h1>
         </header>
 
         <main class="flex-1 flex flex-col items-center justify-center">
           <ng-container *ngIf="!isWaiting(viewModel); else waitingScreen">
-            <div class="justify-center items-center p-8 shadow-sm h-full w-1/2">
-              <p class="text-2xl text-center mb-5">Vota por quien es el traidor</p>
+            <div class="justify-center items-center p-8 h-full w-11/12 max-w-2xl tpm-panel">
+              <p class="text-2xl text-center mb-5 tpm-highlight">Vota por quien es el traidor</p>
               <form class="flex flex-col items-center gap-6" (ngSubmit)="onSubmit(viewModel)">
-                <div class="flex flex-col gap-2">
-                  <label class="font-bold">¿Quién es el traidor?</label>
+                <div class="flex flex-col gap-3 text-lg">
+                  <label class="font-bold tpm-accent">¿Quién es el traidor?</label>
 
                   <label
-                    class="flex items-center gap-2"
+                    class="flex items-center gap-3 text-slate-100"
                     *ngFor="let option of availableOptions"
                   >
                     <input
@@ -39,7 +39,7 @@ import { PlayerViewModel, VoteOption } from '../models';
                     {{ option.playerName }}
                   </label>
 
-                  <label class="flex items-center gap-2">
+                  <label class="flex items-center gap-3 text-slate-100">
                     <input
                       type="radio"
                       name="voto"
@@ -51,13 +51,13 @@ import { PlayerViewModel, VoteOption } from '../models';
                   </label>
                 </div>
                 <button
-                  class="text-4xl font-bold underline hover:text-gray-700 disabled:text-gray-400"
+                  class="tpm-button text-3xl font-bold"
                   type="submit"
                   [disabled]="submitting || !selectedVote"
                 >
                   Votar
                 </button>
-                <p *ngIf="submitError" class="text-red-600 text-base text-center">
+                <p *ngIf="submitError" class="text-red-300 text-base text-center">
                   {{ submitError }}
                 </p>
               </form>
@@ -69,16 +69,16 @@ import { PlayerViewModel, VoteOption } from '../models';
               <div>
                 <div class="flex flex-col items-center gap-4">
                   <div
-                    class="w-48 h-48 rounded-full border-2 border-gray-300 bg-gray-100 flex items-center justify-center"
+                    class="w-48 h-48 rounded-full flex items-center justify-center tpm-avatar"
                     aria-label="Avatar del jugador"
                   >
-                    <span class="text-6xl font-bold text-gray-400">
+                    <span class="text-6xl font-bold tpm-avatar-letter">
                       {{ (viewModel.name || 'J')[0] }}
                     </span>
                   </div>
-                  <p class="text-4xl text-center">{{ viewModel.name || 'Jugador' }}</p>
+                  <p class="text-4xl text-center tpm-highlight">{{ viewModel.name || 'Jugador' }}</p>
                 </div>
-                <div class="m-5">
+                <div class="m-5 tpm-panel px-8 py-6">
                   <p class="text-2xl text-center">Esperando a que todos contesten...</p>
                 </div>
               </div>

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,6 +1,114 @@
+@import url('https://fonts.googleapis.com/css2?family=Creepster&family=Inter:wght@400;600;700&display=swap');
+
+:root {
+  --tpm-blue-deep: #0b0f2b;
+  --tpm-blue-mid: #1a1d4f;
+  --tpm-green-glow: #2fe6a8;
+  --tpm-green-dark: #0d5e4a;
+  --tpm-pink-neon: #ff4fd2;
+  --tpm-purple: #5c3ea6;
+  --tpm-cream: #f8f1ff;
+  --tpm-red: #d81e3a;
+}
+
 html,
 body {
   margin: 0;
   font-family: 'Inter', 'Segoe UI', system-ui, sans-serif;
-  background-color: #ffffff;
+  background-color: var(--tpm-blue-deep);
+  color: var(--tpm-cream);
+}
+
+body {
+  min-height: 100vh;
+  background: radial-gradient(circle at top, #2a2d6d 0%, var(--tpm-blue-deep) 55%, #050714 100%);
+}
+
+.tpm-root {
+  min-height: 100vh;
+  background: radial-gradient(circle at 20% 20%, rgba(92, 62, 166, 0.35), transparent 55%),
+    radial-gradient(circle at 80% 10%, rgba(47, 230, 168, 0.2), transparent 50%),
+    radial-gradient(circle at 50% 80%, rgba(255, 79, 210, 0.2), transparent 55%);
+  color: var(--tpm-cream);
+}
+
+.tpm-header {
+  background: linear-gradient(120deg, rgba(8, 11, 28, 0.98), rgba(26, 29, 79, 0.95));
+  border-bottom: 2px solid rgba(47, 230, 168, 0.6);
+  box-shadow: 0 10px 30px rgba(5, 7, 20, 0.7);
+}
+
+.tpm-title {
+  font-family: 'Creepster', 'Inter', system-ui, sans-serif;
+  color: var(--tpm-pink-neon);
+  text-shadow: 0 0 12px rgba(255, 79, 210, 0.9), 0 0 24px rgba(47, 230, 168, 0.4);
+  letter-spacing: 0.2em;
+}
+
+.tpm-panel {
+  background: rgba(7, 10, 28, 0.85);
+  border: 2px solid rgba(47, 230, 168, 0.7);
+  border-radius: 24px;
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.55), inset 0 0 18px rgba(47, 230, 168, 0.1);
+  backdrop-filter: blur(6px);
+}
+
+.tpm-input {
+  background: rgba(5, 7, 20, 0.9);
+  border: 2px solid rgba(47, 230, 168, 0.7);
+  color: var(--tpm-cream);
+  border-radius: 16px;
+  box-shadow: inset 0 0 10px rgba(47, 230, 168, 0.12);
+}
+
+.tpm-input::placeholder {
+  color: rgba(248, 241, 255, 0.55);
+}
+
+.tpm-button {
+  background: linear-gradient(140deg, rgba(255, 79, 210, 0.9), rgba(92, 62, 166, 0.9));
+  border: 2px solid rgba(47, 230, 168, 0.7);
+  color: var(--tpm-cream);
+  padding: 0.6rem 2.6rem;
+  border-radius: 999px;
+  text-transform: uppercase;
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.45), 0 0 16px rgba(255, 79, 210, 0.5);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, filter 0.2s ease;
+}
+
+.tpm-button:hover {
+  transform: translateY(-1px) scale(1.01);
+  box-shadow: 0 16px 30px rgba(0, 0, 0, 0.55), 0 0 22px rgba(47, 230, 168, 0.6);
+}
+
+.tpm-button:disabled {
+  filter: grayscale(0.7);
+  opacity: 0.6;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.tpm-avatar {
+  background: radial-gradient(circle at top, rgba(47, 230, 168, 0.35), rgba(7, 10, 28, 0.95));
+  border: 3px solid rgba(47, 230, 168, 0.7);
+  box-shadow: 0 0 24px rgba(47, 230, 168, 0.4), inset 0 0 16px rgba(255, 79, 210, 0.2);
+}
+
+.tpm-avatar-letter {
+  color: rgba(248, 241, 255, 0.9);
+  text-shadow: 0 0 10px rgba(255, 79, 210, 0.7);
+}
+
+.tpm-highlight {
+  color: var(--tpm-pink-neon);
+  text-shadow: 0 0 12px rgba(255, 79, 210, 0.7);
+}
+
+.tpm-accent {
+  color: rgba(47, 230, 168, 0.9);
+}
+
+.tpm-danger {
+  color: #ff5c5c;
+  text-shadow: 0 0 8px rgba(255, 92, 92, 0.6);
 }


### PR DESCRIPTION
### Motivation
- Give the player-facing UI a Trivia Murder Party (T.M.P.) inspired aesthetic so screens match the provided visual reference and feel cohesive across the app.

### Description
- Add a global theme and reusable utility classes (`.tpm-root`, `.tpm-header`, `.tpm-title`, `.tpm-panel`, `.tpm-input`, `.tpm-button`, `.tpm-avatar`, etc.) in `src/styles.css` to define colors, typography and treatments. 
- Wrap the shell with the themed background by adding `tpm-root` in `src/app/player/game-shell.component.ts`.
- Restyle player screens to consume the new theme by updating header/title, panels, inputs, buttons and avatar treatments in `src/app/player/ui/join-room.component.ts`, `lobby.component.ts`, `role-assignment.component.ts`, `answer.component.ts`, `vote.component.ts`, `debate.component.ts`, and `results.component.ts`.
- Tweak spacing, radio/label classes and error color tokens so the components render consistently with the new palette.

### Testing
- Built and served the app using `npm start` (runs `ng serve`) and the build completed successfully and served on `http://localhost:4200/`.
- Ran a small Playwright script to load the app and capture a screenshot, producing `artifacts/tpm-join-room.png`.
- No unit tests were added or changed for this UI-only styling update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e80e49288832db2a834832ced99db)