### PR TITLE
Add avatar image rendering based on avatarId

### DIFF
--- a/src/app/player/ui/answer.component.ts
+++ b/src/app/player/ui/answer.component.ts
@@ -4,11 +4,12 @@ import { FormsModule } from '@angular/forms';
 import { finalize } from 'rxjs';
 import { PlayerApiService } from '../player-api.service';
 import { PlayerViewModel } from '../models';
+import { AvatarImageUrlPipe } from './avatar-image-url.pipe';
 
 @Component({
   selector: 'player-answer',
   standalone: true,
-  imports: [CommonModule, FormsModule],
+  imports: [CommonModule, FormsModule, AvatarImageUrlPipe],
   template: `
     <ng-container *ngIf="vm as viewModel">
       <div class="h-full w-full overflow-hidden flex flex-col tmp-shell">
@@ -55,9 +56,20 @@ import { PlayerViewModel } from '../models';
                     class="w-48 h-48 rounded-full flex items-center justify-center tmp-avatar"
                     aria-label="Avatar del jugador"
                   >
-                    <span class="text-6xl font-bold text-gray-200">
-                      {{ (viewModel.name || 'J')[0] }}
-                    </span>
+                    <ng-container
+                      *ngIf="(viewModel.avatarId | avatarImageUrl) as avatarUrl; else initials"
+                    >
+                      <img
+                        class="tmp-avatar-image"
+                        [src]="avatarUrl"
+                        [alt]="viewModel.name ? 'Avatar de ' + viewModel.name : 'Avatar del jugador'"
+                      />
+                    </ng-container>
+                    <ng-template #initials>
+                      <span class="text-6xl font-bold text-gray-200">
+                        {{ (viewModel.name || 'J')[0] }}
+                      </span>
+                    </ng-template>
                   </div>
                   <p class="text-4xl text-center tmp-copy">
                     {{ viewModel.name || 'Jugador' }}

--- a/src/app/player/ui/avatar-image-url.pipe.ts
+++ b/src/app/player/ui/avatar-image-url.pipe.ts
@@ -1,0 +1,15 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'avatarImageUrl',
+  standalone: true,
+})
+export class AvatarImageUrlPipe implements PipeTransform {
+  transform(avatarId: number | null | undefined): string | null {
+    if (avatarId === null || avatarId === undefined) {
+      return null;
+    }
+
+    return `assets/img/avatar_${avatarId}.png`;
+  }
+}

--- a/src/app/player/ui/debate.component.ts
+++ b/src/app/player/ui/debate.component.ts
@@ -1,11 +1,12 @@
 import { Component, Input } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { PlayerViewModel } from '../models';
+import { AvatarImageUrlPipe } from './avatar-image-url.pipe';
 
 @Component({
   selector: 'player-debate',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, AvatarImageUrlPipe],
   template: `
     <div class="flex flex-col items-center justify-center h-full gap-8 tmp-shell">
       <header class="fixed top-0 w-full z-50 tmp-header">
@@ -17,9 +18,18 @@ import { PlayerViewModel } from '../models';
           class="w-48 h-48 rounded-full flex items-center justify-center tmp-avatar"
           aria-label="Avatar del jugador"
         >
-          <span class="text-6xl font-bold text-gray-200">
-            {{ (vm?.name || 'J')[0] }}
-          </span>
+          <ng-container *ngIf="(vm?.avatarId | avatarImageUrl) as avatarUrl; else initials">
+            <img
+              class="tmp-avatar-image"
+              [src]="avatarUrl"
+              [alt]="vm?.name ? 'Avatar de ' + vm?.name : 'Avatar del jugador'"
+            />
+          </ng-container>
+          <ng-template #initials>
+            <span class="text-6xl font-bold text-gray-200">
+              {{ (vm?.name || 'J')[0] }}
+            </span>
+          </ng-template>
         </div>
         <p class="text-4xl text-center mt-4 tmp-copy">
           {{ vm?.name || 'nombre player' }}

--- a/src/app/player/ui/lobby.component.ts
+++ b/src/app/player/ui/lobby.component.ts
@@ -1,11 +1,12 @@
 import { Component, Input } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { PlayerViewModel } from '../models';
+import { AvatarImageUrlPipe } from './avatar-image-url.pipe';
 
 @Component({
   selector: 'player-lobby',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, AvatarImageUrlPipe],
   template: `
     <div class="flex flex-col items-center justify-center h-full gap-8 tmp-shell">
       <header class="fixed top-0 w-full z-50 tmp-header">
@@ -18,9 +19,18 @@ import { PlayerViewModel } from '../models';
             class="w-48 h-48 rounded-full flex items-center justify-center tmp-avatar"
             aria-label="Avatar del jugador"
           >
-            <span class="text-6xl font-bold text-gray-200">
-              {{ (vm?.name || 'J')[0] }}
-            </span>
+            <ng-container *ngIf="(vm?.avatarId | avatarImageUrl) as avatarUrl; else initials">
+              <img
+                class="tmp-avatar-image"
+                [src]="avatarUrl"
+                [alt]="vm?.name ? 'Avatar de ' + vm?.name : 'Avatar del jugador'"
+              />
+            </ng-container>
+            <ng-template #initials>
+              <span class="text-6xl font-bold text-gray-200">
+                {{ (vm?.name || 'J')[0] }}
+              </span>
+            </ng-template>
           </div>
           <p class="text-4xl text-center tmp-copy">{{ vm?.name || 'Jugador' }}</p>
         </div>

--- a/src/app/player/ui/role-assignment.component.ts
+++ b/src/app/player/ui/role-assignment.component.ts
@@ -1,11 +1,12 @@
 import { Component, Input } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { PlayerViewModel } from '../models';
+import { AvatarImageUrlPipe } from './avatar-image-url.pipe';
 
 @Component({
   selector: 'player-role-assignment',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, AvatarImageUrlPipe],
   template: `
     <div class="flex flex-col items-center justify-center h-full gap-8 tmp-shell">
       <header class="fixed top-0 w-full z-50 tmp-header">
@@ -18,9 +19,18 @@ import { PlayerViewModel } from '../models';
             class="w-48 h-48 rounded-full flex items-center justify-center overflow-hidden tmp-avatar"
             aria-label="Avatar del jugador"
           >
-            <span class="text-6xl font-bold text-gray-200">
-              {{ (vm?.name || 'J')[0] }}
-            </span>
+            <ng-container *ngIf="(vm?.avatarId | avatarImageUrl) as avatarUrl; else initials">
+              <img
+                class="tmp-avatar-image"
+                [src]="avatarUrl"
+                [alt]="vm?.name ? 'Avatar de ' + vm?.name : 'Avatar del jugador'"
+              />
+            </ng-container>
+            <ng-template #initials>
+              <span class="text-6xl font-bold text-gray-200">
+                {{ (vm?.name || 'J')[0] }}
+              </span>
+            </ng-template>
           </div>
           <p class="text-4xl text-center tmp-copy">{{ vm?.name || 'Jugador' }}</p>
         </div>

--- a/src/app/player/ui/vote.component.ts
+++ b/src/app/player/ui/vote.component.ts
@@ -5,11 +5,12 @@ import { finalize } from 'rxjs';
 import { PlayerApiService } from '../player-api.service';
 import { PlayerClientService } from '../player-client.service';
 import { PlayerViewModel, VoteOption } from '../models';
+import { AvatarImageUrlPipe } from './avatar-image-url.pipe';
 
 @Component({
   selector: 'player-vote',
   standalone: true,
-  imports: [CommonModule, FormsModule],
+  imports: [CommonModule, FormsModule, AvatarImageUrlPipe],
   template: `
     <ng-container *ngIf="vm as viewModel">
       <div class="h-full w-full overflow-hidden flex flex-col tmp-shell">
@@ -88,9 +89,20 @@ import { PlayerViewModel, VoteOption } from '../models';
                     class="w-48 h-48 rounded-full flex items-center justify-center tmp-avatar"
                     aria-label="Avatar del jugador"
                   >
-                    <span class="text-6xl font-bold text-gray-200">
-                      {{ (viewModel.name || 'J')[0] }}
-                    </span>
+                    <ng-container
+                      *ngIf="(viewModel.avatarId | avatarImageUrl) as avatarUrl; else initials"
+                    >
+                      <img
+                        class="tmp-avatar-image"
+                        [src]="avatarUrl"
+                        [alt]="viewModel.name ? 'Avatar de ' + viewModel.name : 'Avatar del jugador'"
+                      />
+                    </ng-container>
+                    <ng-template #initials>
+                      <span class="text-6xl font-bold text-gray-200">
+                        {{ (viewModel.name || 'J')[0] }}
+                      </span>
+                    </ng-template>
                   </div>
                   <p class="text-4xl text-center tmp-copy">
                     {{ viewModel.name || 'Jugador' }}

--- a/src/styles.css
+++ b/src/styles.css
@@ -121,6 +121,13 @@ body {
   box-shadow: 0 0 24px rgba(54, 242, 163, 0.2);
 }
 
+.tmp-avatar-image {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  display: block;
+}
+
 .tmp-role-good {
   color: var(--neon-green);
   text-shadow: 0 0 12px rgba(54, 242, 163, 0.5);


### PR DESCRIPTION
### Motivation
- Render the player avatar image indicated by the snapshot `avatarId` using the local `assets/img` files with a fallback to initials when no avatar is available.
- Ensure avatars of different intrinsic sizes fit the avatar circle without distortion.

### Description
- Add a standalone pipe `AvatarImageUrlPipe` (`src/app/player/ui/avatar-image-url.pipe.ts`) that maps an `avatarId` to `assets/img/avatar_<id>.png`.
- Update `LobbyComponent`, `RoleAssignmentComponent`, `DebateComponent`, `AnswerComponent`, and `VoteComponent` to render an `<img>` using the pipe and provide a initials fallback `ng-template` when no avatar URL is present.
- Import the pipe into each standalone component and add descriptive `alt` text for accessibility.
- Add `.tmp-avatar-image` CSS to `src/styles.css` with `object-fit: contain` so images scale to the avatar container without being distorted.

### Testing
- Built and served the app with `npm run start` (`ng serve`) to validate the application bundle generation, and the build completed successfully.
- Ran a Playwright script that loaded `http://127.0.0.1:4200` and saved a screenshot (`artifacts/avatar-ui.png`), and the script completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f98fcfa18832d80815a2ce48908a9)